### PR TITLE
Make macos build work.

### DIFF
--- a/Make.osx
+++ b/Make.osx
@@ -8,7 +8,7 @@ CFLAGS=-Wall -Wno-missing-braces -ggdb -I$(ROOT) -I$(ROOT)/include -I$(ROOT)/ker
 O=o
 OS=posix
 GUI=osx
-LDADD=-ggdb -framework Carbon -framework QuickTime
+LDADD=-ggdb -framework Carbon
 LDFLAGS=$(PTHREAD)
 TARG=drawterm
 AUDIO=none
@@ -16,5 +16,5 @@ AUDIO=none
 all: default
 
 libmachdep.a:
-	arch=`uname -m|sed 's/i.86/386/;s/Power Macintosh/power/'`; \
+	arch=`uname -m|sed 's/x86_64/amd64/;s/i.86/386/;s/Power Macintosh/power/'`; \
 	(cd posix-$$arch &&  make)


### PR DESCRIPTION
Removes the unneeded Quicktime framework and adds amd64 to the uname -m remapping.